### PR TITLE
feat: add get_slug_name function to slugify file names

### DIFF
--- a/src/potato_util/_base.py
+++ b/src/potato_util/_base.py
@@ -1,3 +1,5 @@
+import os
+import sys
 import re
 import copy
 import logging
@@ -51,7 +53,33 @@ def camel_to_snake(val: str) -> str:
     return val
 
 
+@validate_call
+def get_slug_name(file_path: str | None = None) -> str:
+    """Slugify the file name from the given file path or the current script's file path.
+
+    Args:
+        file_path (str | None, optional): The file path to slugify. If None, uses the current script's file path.
+                                            Defaults to None.
+
+    Returns:
+        str: The slugified file name.
+    """
+
+    if not file_path:
+        file_path = sys.argv[0]
+
+    _slug_name = (
+        os.path.splitext(os.path.basename(file_path))[0]
+        .strip()
+        .replace(" ", "-")
+        .replace("_", "-")
+        .lower()
+    )
+    return _slug_name
+
+
 __all__ = [
     "deep_merge",
     "camel_to_snake",
+    "get_slug_name",
 ]


### PR DESCRIPTION
This pull request adds a new utility function to the `src/potato_util/_base.py` module and updates the module's imports and exports accordingly. The main change is the introduction of `get_slug_name`, which provides a standardized way to generate slugified names from file paths.

New utility function:

* Added `get_slug_name`, a function that slugifies a file name from a given path or the current script's path, replacing spaces and underscores with hyphens and converting to lowercase.

Module updates:

* Imported `os` and `sys` to support the new file path and name processing in `get_slug_name`.
* Updated the `__all__` list to include `get_slug_name`, making it available for external imports.