### PR TITLE
feat: add is_debug_mode function to check application debug status

### DIFF
--- a/src/potato_util/_base.py
+++ b/src/potato_util/_base.py
@@ -88,17 +88,11 @@ def is_debug_mode() -> bool:
     """
 
     _is_debug = False
-    _debug = ""
-    if "DEBUG" in os.environ:
-        _debug = str(os.getenv("DEBUG")).strip().lower()
-
-    if is_truthy(_debug):
+    _debug = os.getenv("DEBUG", "").strip().lower()
+    if _debug and is_truthy(_debug):
         _is_debug = True
 
-    _env = ""
-    if "ENV" in os.environ:
-        _env = str(os.getenv("ENV")).strip().lower()
-
+    _env = os.getenv("ENV", "").strip().lower()
     if (_env == "development") and (_debug == ""):
         _is_debug = True
 

--- a/src/potato_util/_base.py
+++ b/src/potato_util/_base.py
@@ -6,6 +6,8 @@ import logging
 
 from pydantic import validate_call
 
+from .validator import is_truthy
+
 
 logger = logging.getLogger(__name__)
 
@@ -78,8 +80,34 @@ def get_slug_name(file_path: str | None = None) -> str:
     return _slug_name
 
 
+def is_debug_mode() -> bool:
+    """Check if the application is running in debug mode based on environment variables.
+
+    Returns:
+        bool: True if in debug mode, False otherwise.
+    """
+
+    _is_debug = False
+    _debug = ""
+    if "DEBUG" in os.environ:
+        _debug = str(os.getenv("DEBUG")).strip().lower()
+
+    if is_truthy(_debug):
+        _is_debug = True
+
+    _env = ""
+    if "ENV" in os.environ:
+        _env = str(os.getenv("ENV")).strip().lower()
+
+    if (_env == "development") and (_debug == ""):
+        _is_debug = True
+
+    return _is_debug
+
+
 __all__ = [
     "deep_merge",
     "camel_to_snake",
     "get_slug_name",
+    "is_debug_mode",
 ]


### PR DESCRIPTION
This pull request introduces a new utility function to check if the application is running in debug mode, and updates the module exports accordingly. The changes improve environment-based configuration handling.

**Environment handling:**

* Added the `is_debug_mode` function in `src/potato_util/_base.py` to determine debug mode status based on the `DEBUG` and `ENV` environment variables. This uses the `is_truthy` validator for robust value checking.
* Imported the `is_truthy` function from `src/potato_util/validator.py` to support the new debug mode utility.

**Module exports:**

* Updated the `__all__` list in `src/potato_util/_base.py` to include `is_debug_mode`, making it available for import.