### PR TITLE
feat: add async and sync functions to read YAML, JSON, TOML, and INI …

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -133,7 +133,11 @@ repos:
       - id: flake8
         name: "🐍 flake8 - Lint python code"
         files: \.pyi?$
-        args: ["--max-line-length=120"]
+        args:
+          [
+            "--max-line-length=120",
+            "--per-file-ignores=src/potato_util/io/_sync.py:E402,src/potato_util/io/_async.py:E402",
+          ]
 
   - repo: https://github.com/PyCQA/bandit
     rev: 1.8.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+toml>=0.10.2; python_version < "3.11"
+PyYAML>=6.0.2,<7.0.0
 python-dotenv>=1.0.1,<2.0.0
 pydantic[email,timezone]>=2.0.3,<3.0.0
 pydantic-settings>=2.2.1,<3.0.0

--- a/src/potato_util/io/_async.py
+++ b/src/potato_util/io/_async.py
@@ -386,11 +386,12 @@ async def async_read_toml_file(file_path: str | Path) -> dict[str, Any]:
         if _binary_toml:
             async with aiofiles.open(file_path, "rb") as _file:
                 _content = await _file.read()  # type: ignore
+                _data = tomllib.load(_content) or {}
         else:
             async with aiofiles.open(file_path, "r", encoding="utf-8") as _file:
                 _content = await _file.read()  # type: ignore
+                _data = tomllib.loads(_content) or {}
 
-        _data = tomllib.loads(_content) or {}
     except Exception:
         logger.error(f"Failed to read '{file_path}' TOML file!")
         raise
@@ -440,8 +441,20 @@ async def async_read_ini_file(file_path: str | Path) -> dict[str, Any]:
 
 @validate_call
 async def async_read_config_file(config_path: str | Path) -> dict[str, Any]:
+    """Read config file (YAML, JSON, TOML, INI).
 
-    _config: dict[str, str] = {}
+    Args:
+        config_path (str | Path, required): Config file path.
+
+    Raises:
+        FileNotFoundError: If config file is not found.
+        ValueError        : If config file format is not supported.
+
+    Returns:
+        dict[str, Any]: Config file data as dictionary.
+    """
+
+    _config: dict[str, Any] = {}
 
     if isinstance(config_path, str):
         config_path = Path(config_path)

--- a/src/potato_util/io/_async.py
+++ b/src/potato_util/io/_async.py
@@ -292,7 +292,7 @@ async def async_get_file_checksum(
 
 @validate_call
 async def async_read_yaml_file(file_path: str | Path) -> dict[str, Any]:
-    """Read YAML file.
+    """Asynchronous read YAML file.
 
     Args:
         file_path (str | Path, required): YAML file path.
@@ -326,7 +326,7 @@ async def async_read_yaml_file(file_path: str | Path) -> dict[str, Any]:
 
 @validate_call
 async def async_read_json_file(file_path: str | Path) -> dict[str, Any]:
-    """Read JSON file.
+    """Asynchronous read JSON file.
 
     Args:
         file_path (str | Path, required): JSON file path.
@@ -360,7 +360,7 @@ async def async_read_json_file(file_path: str | Path) -> dict[str, Any]:
 
 @validate_call
 async def async_read_toml_file(file_path: str | Path) -> dict[str, Any]:
-    """Read TOML file.
+    """Asynchronous read TOML file.
 
     Args:
         file_path (str | Path, required): TOML file path.
@@ -401,7 +401,7 @@ async def async_read_toml_file(file_path: str | Path) -> dict[str, Any]:
 
 @validate_call
 async def async_read_ini_file(file_path: str | Path) -> dict[str, Any]:
-    """Read INI config file.
+    """Asynchronous read INI config file.
 
     Args:
         file_path (str | Path, required): INI config file path.
@@ -441,7 +441,7 @@ async def async_read_ini_file(file_path: str | Path) -> dict[str, Any]:
 
 @validate_call
 async def async_read_config_file(config_path: str | Path) -> dict[str, Any]:
-    """Read config file (YAML, JSON, TOML, INI).
+    """Asynchronous read config file (YAML, JSON, TOML, INI).
 
     Args:
         config_path (str | Path, required): Config file path.

--- a/src/potato_util/io/_sync.py
+++ b/src/potato_util/io/_sync.py
@@ -1,10 +1,27 @@
+# noqa: E402
+
 import os
+import sys
+import json
 import errno
 import shutil
 import hashlib
 import logging
+import configparser
+from pathlib import Path
+from typing import Any
 
+_binary_toml = False
+if sys.version_info >= (3, 11):
+    import tomllib  # type: ignore
+
+    _binary_toml = True
+else:
+    import toml as tomllib  # type: ignore
+
+import yaml
 from pydantic import validate_call
+
 
 from ..constants import WarnEnum, HashAlgoEnum, MAX_PATH_LENGTH
 
@@ -270,6 +287,185 @@ def get_file_checksum(
     return _file_checksum
 
 
+@validate_call
+def read_yaml_file(file_path: str | Path) -> dict[str, Any]:
+    """Read YAML file.
+
+    Args:
+        file_path (str | Path, required): YAML file path.
+
+    Raises:
+        FileNotFoundError: If YAML file is not found.
+        Exception        : If failed to read YAML file.
+
+    Returns:
+        dict[str, Any]: YAML file data as dictionary.
+    """
+
+    _data: dict[str, str] = {}
+
+    if isinstance(file_path, str):
+        file_path = Path(file_path)
+
+    if not os.path.isfile(file_path):
+        raise FileNotFoundError(f"Not found '{file_path}' YAML file!")
+
+    try:
+        with open(file_path, encoding="utf-8") as _file:
+            _data = yaml.safe_load(_file) or {}
+    except Exception:
+        logger.error(f"Failed to read '{file_path}' YAML file!")
+        raise
+
+    return _data
+
+
+@validate_call
+def read_json_file(file_path: str | Path) -> dict[str, Any]:
+    """Read JSON file.
+
+    Args:
+        file_path (str | Path, required): JSON file path.
+
+    Raises:
+        FileNotFoundError: If JSON file is not found.
+        Exception        : If failed to read JSON file.
+
+    Returns:
+        dict[str, Any]: JSON file data as dictionary.
+    """
+
+    _data: dict[str, Any] = {}
+
+    if isinstance(file_path, str):
+        file_path = Path(file_path)
+
+    if not os.path.isfile(file_path):
+        raise FileNotFoundError(f"Not found '{file_path}' JSON file!")
+
+    try:
+        with open(file_path, encoding="utf-8") as _file:
+            _data = json.load(_file) or {}
+    except Exception:
+        logger.error(f"Failed to read '{file_path}' JSON file!")
+        raise
+
+    return _data
+
+
+@validate_call
+def read_toml_file(file_path: str | Path) -> dict[str, Any]:
+    """Read TOML file.
+
+    Args:
+        file_path (str | Path, required): TOML file path.
+
+    Raises:
+        FileNotFoundError: If TOML file is not found.
+        Exception        : If failed to read TOML file.
+
+    Returns:
+        dict[str, Any]: TOML file data as dictionary.
+    """
+
+    _data: dict[str, Any] = {}
+
+    if isinstance(file_path, str):
+        file_path = Path(file_path)
+
+    if not os.path.isfile(file_path):
+        raise FileNotFoundError(f"Not found '{file_path}' TOML file!")
+
+    try:
+        if _binary_toml:
+            with open(file_path, "rb") as _file:
+                _data = tomllib.load(_file) or {}  # type: ignore
+        else:
+            with open(file_path, encoding="utf-8") as _file:
+                _data = tomllib.load(_file) or {}  # type: ignore
+    except Exception:
+        logger.error(f"Failed to read '{file_path}' TOML file!")
+        raise
+
+    return _data
+
+
+@validate_call
+def read_ini_file(file_path: str | Path) -> dict[str, Any]:
+    """Read INI config file.
+
+    Args:
+        file_path (str | Path, required): INI config file path.
+
+    Raises:
+        FileNotFoundError: If INI config file is not found.
+        Exception        : If failed to read INI config file.
+
+    Returns:
+        dict[str, Any]: INI config file data as dictionary.
+    """
+
+    _config: dict[str, Any] = {}
+
+    if isinstance(file_path, str):
+        file_path = Path(file_path)
+
+    if not os.path.isfile(file_path):
+        raise FileNotFoundError(f"Not found '{file_path}' INI config file!")
+
+    try:
+        _config_parser = configparser.ConfigParser()
+        _config_parser.read(file_path)
+        for _section in _config_parser.sections():
+            _config[_section] = dict(_config_parser.items(_section))
+
+    except Exception:
+        logger.error(f"Failed to read '{file_path}' INI config file!")
+        raise
+
+    return _config
+
+
+@validate_call
+def read_config_file(config_path: str | Path) -> dict[str, Any]:
+    """Read config file (YAML, JSON, TOML, INI).
+
+    Args:
+        config_path (str | Path, required): Config file path.
+
+    Raises:
+        FileNotFoundError: If config file is not found.
+        ValueError       : If config file format is not supported.
+
+    Returns:
+        dict[str, Any]: Config file data as dictionary.
+    """
+
+    _config: dict[str, Any] = {}
+
+    if isinstance(config_path, str):
+        config_path = Path(config_path)
+
+    if not os.path.isfile(config_path):
+        raise FileNotFoundError(f"Not found '{config_path}' config file!")
+
+    _suffix = config_path.suffix.lower()
+    if _suffix in (".yaml", ".yml"):
+        _config = read_yaml_file(file_path=config_path)
+    elif _suffix == ".json":
+        _config = read_json_file(file_path=config_path)
+    elif _suffix == ".toml":
+        _config = read_toml_file(file_path=config_path)
+    elif _suffix in (".ini", ".cfg"):
+        _config = read_ini_file(file_path=config_path)
+    else:
+        raise ValueError(
+            f"Unsupported config file format '{config_path.suffix}' for '{config_path}'!"
+        )
+
+    return _config
+
+
 __all__ = [
     "create_dir",
     "remove_dir",
@@ -277,4 +473,9 @@ __all__ = [
     "remove_file",
     "remove_files",
     "get_file_checksum",
+    "read_yaml_file",
+    "read_json_file",
+    "read_toml_file",
+    "read_ini_file",
+    "read_config_file",
 ]

--- a/src/potato_util/io/_sync.py
+++ b/src/potato_util/io/_sync.py
@@ -302,7 +302,7 @@ def read_yaml_file(file_path: str | Path) -> dict[str, Any]:
         dict[str, Any]: YAML file data as dictionary.
     """
 
-    _data: dict[str, str] = {}
+    _data: dict[str, Any] = {}
 
     if isinstance(file_path, str):
         file_path = Path(file_path)


### PR DESCRIPTION
This pull request adds robust support for reading configuration files in multiple formats (YAML, JSON, TOML, INI) in both synchronous and asynchronous IO utility modules. It introduces new functions for reading each format and a unified function to read any supported config file type, streamlining config file parsing across the codebase. Additionally, it updates the pre-commit configuration to ignore specific linting errors for these files.

**Config file reading enhancements:**

* Added new async functions (`async_read_yaml_file`, `async_read_json_file`, `async_read_toml_file`, `async_read_ini_file`, `async_read_config_file`) to `src/potato_util/io/_async.py` for reading YAML, JSON, TOML, and INI files, plus a unified config file reader supporting all formats. [[1]](diffhunk://#diff-051cc02c1cb792336b3358ef68cee00cc8f7ad6bf6a6e266ba63cc2f57e4b697R1-R18) [[2]](diffhunk://#diff-051cc02c1cb792336b3358ef68cee00cc8f7ad6bf6a6e266ba63cc2f57e4b697R293-R480)
* Added new sync functions (`read_yaml_file`, `read_json_file`, `read_toml_file`, `read_ini_file`, `read_config_file`) to `src/potato_util/io/_sync.py` for reading YAML, JSON, TOML, and INI files, plus a unified config file reader supporting all formats. [[1]](diffhunk://#diff-e4ea053a6c67c79ea57b17e7dc01711affd05eca0599f5167e915f729c0ccd3bR1-R25) [[2]](diffhunk://#diff-e4ea053a6c67c79ea57b17e7dc01711affd05eca0599f5167e915f729c0ccd3bR290-R480)

**Pre-commit configuration update:**

* Updated `.pre-commit-config.yaml` to ignore linting error E402 (module imports not at top of file) for the newly modified IO utility files.