### PR TITLE
feat: add support for reading multiple config file formats asynchrono…

### DIFF
--- a/src/potato_util/constants/_enum.py
+++ b/src/potato_util/constants/_enum.py
@@ -24,8 +24,16 @@ class HashAlgoEnum(str, Enum):
     sha512 = "sha512"
 
 
+class ConfigFileFormatEnum(str, Enum):
+    YAML = "YAML"
+    JSON = "JSON"
+    TOML = "TOML"
+    INI = "INI"
+
+
 __all__ = [
     "WarnEnum",
     "TSUnitEnum",
     "HashAlgoEnum",
+    "ConfigFileFormatEnum",
 ]

--- a/src/potato_util/io/_async.py
+++ b/src/potato_util/io/_async.py
@@ -1,5 +1,7 @@
+import os
 import sys
 import json
+import glob
 import errno
 import hashlib
 import logging
@@ -20,7 +22,8 @@ import aioshutil
 import aiofiles.os
 from pydantic import validate_call
 
-from ..constants import WarnEnum, HashAlgoEnum, MAX_PATH_LENGTH
+from .._base import deep_merge
+from ..constants import WarnEnum, HashAlgoEnum, ConfigFileFormatEnum, MAX_PATH_LENGTH
 
 
 logger = logging.getLogger(__name__)
@@ -479,6 +482,63 @@ async def async_read_config_file(config_path: str | Path) -> dict[str, Any]:
     return _config
 
 
+@validate_call
+async def async_read_all_configs(
+    configs_dir: str | Path | list[str | Path],
+    allowed_formats: list[ConfigFileFormatEnum] = [
+        ConfigFileFormatEnum.YAML,
+        ConfigFileFormatEnum.JSON,
+        ConfigFileFormatEnum.TOML,
+    ],
+) -> dict[str, Any]:
+    """Asynchronous read all config files from directory or directories and merge them.
+
+    Args:
+        configs_dir     (str | Path | list[str | Path], required): Configs directory or directories.
+        allowed_formats (list[ConfigFileFormatEnum]   , optional): Allowed config file formats to read.
+                                                                    Defaults to [YAML, JSON, TOML].
+
+    Returns:
+        dict[str, Any]: Dictionary containing all merged config data from all files.
+    """
+
+    _config_dict: dict[str, Any] = {}
+
+    if not isinstance(configs_dir, list):
+        configs_dir = [configs_dir]
+
+    _file_paths: list[str] = []
+    for _config_dir in configs_dir:
+        if isinstance(_config_dir, str):
+            _config_dir = Path(_config_dir)
+
+        if not os.path.isabs(_config_dir):
+            _current_dir = await aiofiles.os.getcwd()
+            _config_dir = os.path.join(_current_dir, _config_dir)
+
+        if await aiofiles.os.path.isdir(_config_dir):
+            if ConfigFileFormatEnum.YAML in allowed_formats:
+                _file_paths.extend(glob.glob(os.path.join(_config_dir, "*.yaml")))
+                _file_paths.extend(glob.glob(os.path.join(_config_dir, "*.yml")))
+
+            if ConfigFileFormatEnum.JSON in allowed_formats:
+                _file_paths.extend(glob.glob(os.path.join(_config_dir, "*.json")))
+
+            if ConfigFileFormatEnum.TOML in allowed_formats:
+                _file_paths.extend(glob.glob(os.path.join(_config_dir, "*.toml")))
+
+            if ConfigFileFormatEnum.INI in allowed_formats:
+                _file_paths.extend(glob.glob(os.path.join(_config_dir, "*.ini")))
+                _file_paths.extend(glob.glob(os.path.join(_config_dir, "*.cfg")))
+
+    _file_paths.sort()
+    for _file_path in _file_paths:
+        _config_data = await async_read_config_file(config_path=_file_path)
+        _config_dict = deep_merge(_config_dict, _config_data)
+
+    return _config_dict
+
+
 __all__ = [
     "async_create_dir",
     "async_remove_dir",
@@ -491,4 +551,5 @@ __all__ = [
     "async_read_toml_file",
     "async_read_ini_file",
     "async_read_config_file",
+    "async_read_all_configs",
 ]


### PR DESCRIPTION
This pull request adds new functionality for reading and merging multiple configuration files in both asynchronous and synchronous workflows, and introduces a new enum to standardize supported config formats. The changes improve flexibility when loading configuration data from directories, supporting multiple formats and merging them into a single dictionary.

**Config format support:**

* Added `ConfigFileFormatEnum` to `src/potato_util/constants/_enum.py`, defining supported config file formats: YAML, JSON, TOML, and INI.

**Asynchronous config reading enhancements (`src/potato_util/io/_async.py`):**

* Introduced `async_read_all_configs`, an async function to read and merge all config files from one or more directories, supporting multiple formats as specified by `ConfigFileFormatEnum`.
* Updated imports and dependencies to support new functionality, including `glob` for file matching and `deep_merge` for merging configs. [[1]](diffhunk://#diff-051cc02c1cb792336b3358ef68cee00cc8f7ad6bf6a6e266ba63cc2f57e4b697R1-R4) [[2]](diffhunk://#diff-051cc02c1cb792336b3358ef68cee00cc8f7ad6bf6a6e266ba63cc2f57e4b697L23-R26)
* Exported `async_read_all_configs` in the module’s `__all__` list for public API access.

**Synchronous config reading enhancements (`src/potato_util/io/_sync.py`):**

* Added `read_all_configs`, a synchronous function mirroring the async version, to read and merge config files from directories, supporting the same formats.
* Updated imports and dependencies to support new functionality, including `glob` and `deep_merge`. [[1]](diffhunk://#diff-e4ea053a6c67c79ea57b17e7dc01711affd05eca0599f5167e915f729c0ccd3bR6) [[2]](diffhunk://#diff-e4ea053a6c67c79ea57b17e7dc01711affd05eca0599f5167e915f729c0ccd3bL25-R27)
* Exported `read_all_configs` in the module’s `__all__` list for public API access.