### PR TITLE
fix: correct indentation for sorting file paths in read_all_configs f…

### DIFF
--- a/src/potato_util/io/_async.py
+++ b/src/potato_util/io/_async.py
@@ -530,7 +530,8 @@ async def async_read_all_configs(
                 _file_paths.extend(glob.glob(os.path.join(_config_dir, "*.ini")))
                 _file_paths.extend(glob.glob(os.path.join(_config_dir, "*.cfg")))
 
-    _file_paths.sort()
+        _file_paths.sort()
+
     for _file_path in _file_paths:
         _config_data = await async_read_config_file(config_path=_file_path)
         _config_dict = deep_merge(_config_dict, _config_data)

--- a/src/potato_util/io/_sync.py
+++ b/src/potato_util/io/_sync.py
@@ -515,7 +515,8 @@ def read_all_configs(
                 _file_paths.extend(glob.glob(os.path.join(_config_dir, "*.ini")))
                 _file_paths.extend(glob.glob(os.path.join(_config_dir, "*.cfg")))
 
-    _file_paths.sort()
+        _file_paths.sort()
+
     for _file_path in _file_paths:
         _config_data = read_config_file(config_path=_file_path)
         _config_dict = deep_merge(_config_dict, _config_data)


### PR DESCRIPTION
This pull request makes a minor change to the ordering of config file processing in both the async and sync config reading functions. The change ensures that the sorting of `_file_paths` is visually separated from the subsequent loop, improving readability.

* Added a blank line after `_file_paths.sort()` in both `async_read_all_configs` (`src/potato_util/io/_async.py`) and `read_all_configs` (`src/potato_util/io/_sync.py`) to clarify code structure. [[1]](diffhunk://#diff-051cc02c1cb792336b3358ef68cee00cc8f7ad6bf6a6e266ba63cc2f57e4b697R534) [[2]](diffhunk://#diff-e4ea053a6c67c79ea57b17e7dc01711affd05eca0599f5167e915f729c0ccd3bR519)