### PR TITLE
fix: reorder parameters in async_create_ssl_certs and correct typo in…

### DIFF
--- a/requirements/requirements.crypto.txt
+++ b/requirements/requirements.crypto.txt
@@ -1,4 +1,5 @@
 pycparser>=2.22,<4.0.0
 argon2-cffi-bindings>=21.2.0,<30.0.0
 argon2-cffi>=25.1.0,<26.0.0
+cryptography>=44.0.3,<47.0.0
 PyJWT[crypto]>=2.10.1,<3.0.0

--- a/src/potato_util/crypto/ssl/_async.py
+++ b/src/potato_util/crypto/ssl/_async.py
@@ -28,8 +28,8 @@ logger = logging.getLogger(__name__)
 @validate_call
 async def async_create_ssl_certs(
     ssl_dir: str,
-    cert_fname: str,
     key_fname: str,
+    cert_fname: str,
     key_size: int,
     x509_attrs: X509AttrsPM | dict[str, Any] = X509AttrsPM(),
     force: bool = False,
@@ -39,8 +39,8 @@ async def async_create_ssl_certs(
 
     Args:
         ssl_dir    (str                         , required): SSL directory path.
-        cert_fname (str                         , required): Certificate file name.
         key_fname  (str                         , required): Key file name.
+        cert_fname (str                         , required): Certificate file name.
         key_size   (int                         , required): Key size.
         x509_attrs (X509AttrsPM | dict[str, Any], optional): X509 named attributes. Defaults to X509AttrsPM().
         force      (bool                        , optional): Force to create SSL key and cert files. Defaults to False.
@@ -70,11 +70,11 @@ async def async_create_ssl_certs(
         )
         return
 
-    _meesage = f"Generating SSL key and cert files: ['{_key_path}', '{_cert_path}']..."
+    _message = f"Generating SSL key and cert files: ['{_key_path}', '{_cert_path}']..."
     if warn_mode == WarnEnum.ALWAYS:
-        logger.info(_meesage)
+        logger.info(_message)
     elif warn_mode == WarnEnum.DEBUG:
-        logger.debug(_meesage)
+        logger.debug(_message)
 
     _private_key: RSAPrivateKey | PrivateKeyTypes
     if await aiofiles.os.path.isfile(_key_path):


### PR DESCRIPTION
This pull request introduces a new dependency and makes minor improvements to the asynchronous SSL certificate creation utility. The most significant changes are the addition of the `cryptography` package to the requirements and some code cleanups in the `async_create_ssl_certs` function.

Dependency update:

* Added `cryptography` (version >=44.0.3,<47.0.0) to `requirements/requirements.crypto.txt` to support cryptographic operations.

Code cleanup and bugfixes in SSL certificate creation:

* Fixed the order of function parameters and their documentation in `async_create_ssl_certs` to match standard conventions (`key_fname` and `cert_fname` order swapped). [[1]](diffhunk://#diff-efb5d4f6b69de73f943caa6f862db190c01604d7b370d363d989f78d7e4d7e70L31-R32) [[2]](diffhunk://#diff-efb5d4f6b69de73f943caa6f862db190c01604d7b370d363d989f78d7e4d7e70L42-R43)
* Corrected a typo in the variable name (`_meesage` to `_message`) and updated logger calls accordingly in `async_create_ssl_certs`.