### PR TITLE
fix: handle ValueError in is_debug_mode function

### DIFF
--- a/src/potato_util/_base.py
+++ b/src/potato_util/_base.py
@@ -88,8 +88,11 @@ def is_debug_mode() -> bool:
 
     _is_debug = False
     _debug = os.getenv("DEBUG", "").strip().lower()
-    if _debug and is_truthy(_debug):
-        _is_debug = True
+    try:
+        if _debug and is_truthy(_debug):
+            _is_debug = True
+    except ValueError:
+        pass
 
     _env = os.getenv("ENV", "").strip().lower()
     if (_env == "development") and (_debug == ""):


### PR DESCRIPTION
This pull request introduces a minor improvement to the `is_debug_mode()` function by making its handling of the `DEBUG` environment variable more robust. Specifically, it now gracefully ignores any `ValueError` that may be raised when checking if `DEBUG` is truthy.

Error handling enhancement:

* Added a `try`/`except ValueError` block around the logic that checks if the `DEBUG` environment variable is truthy, preventing potential crashes if the value cannot be interpreted. (`src/potato_util/_base.py`)