### PR TITLE
feat(crypto): implement AES-CBC and AES-GCM encryption/decryption fun…

### DIFF
--- a/src/potato_util/constants/_regex.py
+++ b/src/potato_util/constants/_regex.py
@@ -1,5 +1,7 @@
 # Valid characters:
 NUMERIC_REGEX = r"^[0-9]+$"
+ALPHABET_REGEX = r"^[a-zA-Z]+$"
+ALPHABET_HYPHEN_REGEX = r"^[a-zA-Z_\-]+$"
 
 ALPHANUM_REGEX = r"^[0-9a-zA-Z]+$"
 ALPHANUM_SPACE_REGEX = r"^[0-9a-zA-Z ]+$"
@@ -17,6 +19,8 @@ ALPHANUM_KR_MN_PATH_REGEX = r"^[0-9a-zA-Z가-힣А-яҮүӨөЁё_\-. \\\/]+$"
 
 ALPHANUM_TEXT_REGEX = r"^[0-9a-zA-Z_\-.\s]*$"  # Allow empty string, tabs, and newlines
 ALPHANUM_EMPTY_EXTEND_REGEX = r"^[0-9a-zA-Z_\-. ]*$"  # Allow empty string
+
+BASE_ENCRYPTED_REGEX = r"^[0-9a-zA-Z.\/\+=]+$"
 
 REQUEST_ID_REGEX = (
     r"\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b|"
@@ -38,6 +42,9 @@ SPECIAL_CHARS_STRICT_REGEX = r"[&'\"<>\\\/`{}|()\[\]~!@#$%^*_=\-+;:,.?\t\n ]"
 
 
 __all__ = [
+    "NUMERIC_REGEX",
+    "ALPHABET_REGEX",
+    "ALPHABET_HYPHEN_REGEX",
     "ALPHANUM_REGEX",
     "ALPHANUM_SPACE_REGEX",
     "ALPHANUM_HYPHEN_REGEX",
@@ -50,9 +57,9 @@ __all__ = [
     "ALPHANUM_KR_MN_HOST_REGEX",
     "ALPHANUM_KR_MN_EXTEND_REGEX",
     "ALPHANUM_KR_MN_PATH_REGEX",
-    "NUMERIC_REGEX",
     "ALPHANUM_TEXT_REGEX",
     "ALPHANUM_EMPTY_EXTEND_REGEX",
+    "BASE_ENCRYPTED_REGEX",
     "REQUEST_ID_REGEX",
     "HTTP_METHOD_REGEX",
     "ASYMMETRIC_ALGORITHM_REGEX",

--- a/src/potato_util/crypto/symmetric/__init__.py
+++ b/src/potato_util/crypto/symmetric/__init__.py
@@ -1,0 +1,7 @@
+from . import aes_gcm
+from . import aes_cbc
+
+__all__ = [
+    "aes_gcm",
+    "aes_cbc",
+]

--- a/src/potato_util/crypto/symmetric/aes_cbc.py
+++ b/src/potato_util/crypto/symmetric/aes_cbc.py
@@ -5,13 +5,13 @@ from cryptography.hazmat.primitives import ciphers
 from cryptography.hazmat.primitives.ciphers import algorithms, modes
 from pydantic import validate_call
 
-from ..constants import WarnEnum
+from ...constants import WarnEnum
 
 logger = logging.getLogger(__name__)
 
 
 @validate_call(config={"arbitrary_types_allowed": True})
-def decrypt_aes_cbc(
+def decrypt(
     ciphertext: str | bytes,
     key: bytes,
     iv: bytes,
@@ -79,5 +79,5 @@ def decrypt_aes_cbc(
 
 
 __all__ = [
-    "decrypt_aes_cbc",
+    "decrypt",
 ]

--- a/src/potato_util/crypto/symmetric/aes_gcm.py
+++ b/src/potato_util/crypto/symmetric/aes_gcm.py
@@ -1,0 +1,165 @@
+import base64
+import logging
+import secrets
+
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from pydantic import validate_call
+
+from ...constants import WarnEnum
+
+logger = logging.getLogger(__name__)
+
+
+@validate_call(config={"arbitrary_types_allowed": True})
+def encrypt(
+    key: bytes,
+    plaintext: str | bytes,
+    aad: str | bytes | None = None,
+    base64_encode: bool = False,
+    return_str: bool = False,
+    warn_mode: WarnEnum = WarnEnum.DEBUG,
+) -> tuple[str | bytes, str | bytes]:
+    """Encrypts plaintext using AES-GCM key and nonce.
+
+    Args:
+        key           (bytes             , required): The encryption key.
+        plaintext     (str | bytes       , required): The data to be encrypted.
+        aad           (str | bytes | None, optional): Additional authenticated data. Defaults to None.
+        base64_encode (bool              , optional): Whether to base64 encode the nonce and ciphertext.
+                                                        Defaults to False.
+        return_str    (bool              , optional): Whether to return the result as a string. Defaults to False.
+        warn_mode     (WarnEnum          , optional): The warning mode. Defaults to WarnEnum.DEBUG.
+
+    Raises:
+        Exception: If failed to encrypt plaintext using AES-GCM key and nonce for any reason.
+
+    Returns:
+        tuple[str | bytes, str | bytes]: The nonce and ciphertext resulting from the encryption.
+    """
+
+    if isinstance(plaintext, str):
+        plaintext = plaintext.encode()
+
+    if isinstance(aad, str):
+        aad = aad.encode()
+
+    _message = "Encrypting plaintext using AES-GCM key and nonce..."
+    if warn_mode == WarnEnum.ALWAYS:
+        logger.info(_message)
+    elif warn_mode == WarnEnum.DEBUG:
+        logger.debug(_message)
+
+    _nonce: str | bytes
+    _ciphertext: str | bytes
+    try:
+        _aes_gcm = AESGCM(key=key)
+        _nonce = secrets.token_bytes(nbytes=12)
+        _ciphertext = _aes_gcm.encrypt(
+            nonce=_nonce, data=plaintext, associated_data=aad
+        )
+
+        _message = "Successfully encrypted plaintext using AES-GCM key and nonce."
+        if warn_mode == WarnEnum.ALWAYS:
+            logger.info(_message)
+        elif warn_mode == WarnEnum.DEBUG:
+            logger.debug(_message)
+
+    except Exception:
+        _message = "Failed to encrypt plaintext using AES-GCM key and nonce!"
+        if warn_mode == WarnEnum.ALWAYS:
+            logger.error(_message)
+        elif warn_mode == WarnEnum.DEBUG:
+            logger.debug(_message)
+
+        raise
+
+    if base64_encode:
+        _nonce = base64.b64encode(_nonce)
+        _ciphertext = base64.b64encode(_ciphertext)
+
+    if return_str:
+        _nonce = _nonce.decode()
+        _ciphertext = _ciphertext.decode()
+
+    return _nonce, _ciphertext
+
+
+@validate_call(config={"arbitrary_types_allowed": True})
+def decrypt(
+    key: bytes,
+    nonce: str | bytes,
+    ciphertext: str | bytes,
+    aad: str | bytes | None = None,
+    base64_decode: bool = False,
+    return_str: bool = False,
+    warn_mode: WarnEnum = WarnEnum.DEBUG,
+) -> str | bytes:
+    """Decrypts ciphertext using AES-GCM key and nonce.
+
+    Args:
+        key           (bytes             , required): The decryption key.
+        nonce         (str | bytes       , required): The nonce used during encryption.
+        ciphertext    (str | bytes       , required): The data to be decrypted.
+        aad           (str | bytes | None, optional): Additional authenticated data. Defaults to None.
+        base64_decode (bool              , optional): Whether to base64 decode the nonce and ciphertext.
+                                                        Defaults to False.
+        return_str    (bool              , optional): Whether to return the result as a string. Defaults to False.
+        warn_mode     (WarnEnum          , optional): The warning mode. Defaults to WarnEnum.DEBUG.
+
+    Raises:
+        Exception: If failed to decrypt ciphertext using AES-GCM key and nonce for any reason.
+
+    Returns:
+        str | bytes: The decrypted plaintext.
+    """
+
+    if isinstance(nonce, str):
+        nonce = nonce.encode()
+
+    if isinstance(ciphertext, str):
+        ciphertext = ciphertext.encode()
+
+    if isinstance(aad, str):
+        aad = aad.encode()
+
+    if base64_decode:
+        nonce = base64.b64decode(nonce)
+        ciphertext = base64.b64decode(ciphertext)
+        aad = base64.b64decode(aad) if aad else None
+
+    _message = "Decrypting ciphertext using AES-GCM key and nonce..."
+    if warn_mode == WarnEnum.ALWAYS:
+        logger.info(_message)
+    elif warn_mode == WarnEnum.DEBUG:
+        logger.debug(_message)
+
+    _plaintext: str | bytes
+    try:
+        _aes_gcm = AESGCM(key=key)
+        _plaintext = _aes_gcm.decrypt(nonce=nonce, data=ciphertext, associated_data=aad)
+
+        _message = "Successfully decrypted ciphertext using AES-GCM key and nonce."
+        if warn_mode == WarnEnum.ALWAYS:
+            logger.info(_message)
+        elif warn_mode == WarnEnum.DEBUG:
+            logger.debug(_message)
+
+    except Exception:
+        _message = "Failed to decrypt ciphertext using AES-GCM key and nonce!"
+        if warn_mode == WarnEnum.ALWAYS:
+            logger.error(_message)
+        elif warn_mode == WarnEnum.DEBUG:
+            logger.debug(_message)
+
+        raise
+
+    if return_str:
+        _plaintext = _plaintext.decode()
+
+    return _plaintext
+
+
+__all__ = [
+    "encrypt",
+    "decrypt",
+]


### PR DESCRIPTION
This pull request introduces several improvements and refactors to the `potato_util` library, focusing on cryptographic utilities and regex constants. The main highlights are the modularization of symmetric cryptography code, the addition of AES-GCM encryption/decryption support, and the extension of regex constants.

**Symmetric Cryptography Refactor and Enhancements:**

* The symmetric cryptography code has been modularized: the former `symmetric.py` file is now split into `aes_cbc.py` and a new `aes_gcm.py`, with an updated `__init__.py` to expose both modules. This makes the codebase more organized and extensible. [[1]](diffhunk://#diff-7b643005055a6e83212fdfea1b969ce52f6a7be6a20d0a71843830ba0fdbd054R1-R7) [[2]](diffhunk://#diff-b9f959651b3fcdd2c3cc5d3b8e72fbbf12b63039e28bfbefe431e8910c75a3daL8-R14)
* AES-GCM support has been added, including robust `encrypt` and `decrypt` functions with options for base64 encoding/decoding, additional authenticated data (AAD), and configurable logging.
* The AES-CBC decryption function has been renamed from `decrypt_aes_cbc` to `decrypt` for consistency and clarity. [[1]](diffhunk://#diff-b9f959651b3fcdd2c3cc5d3b8e72fbbf12b63039e28bfbefe431e8910c75a3daL8-R14) [[2]](diffhunk://#diff-b9f959651b3fcdd2c3cc5d3b8e72fbbf12b63039e28bfbefe431e8910c75a3daL82-R82)

**Regex Constants Extension:**

* Several new regex patterns have been added to `constants/_regex.py`, including `ALPHABET_REGEX`, `ALPHABET_HYPHEN_REGEX`, and `BASE_ENCRYPTED_REGEX`, expanding the utility and flexibility of input validation. [[1]](diffhunk://#diff-170a28fe4174732b083b9333aab4137dee9fe5719d4e9d05d4358b4278c13528R3-R4) [[2]](diffhunk://#diff-170a28fe4174732b083b9333aab4137dee9fe5719d4e9d05d4358b4278c13528R23-R24)
* The `__all__` export list in `constants/_regex.py` has been updated to include the new regex constants and to remove duplicates. [[1]](diffhunk://#diff-170a28fe4174732b083b9333aab4137dee9fe5719d4e9d05d4358b4278c13528R45-R47) [[2]](diffhunk://#diff-170a28fe4174732b083b9333aab4137dee9fe5719d4e9d05d4358b4278c13528L53-R62)