### PR TITLE
Fix: removed unnecessary base64 decoding of aad in decryption of aes-gsm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,7 @@ updates:
     directory: "/"
     labels:
       - "dependency"
+    versioning-strategy: "widen"
     open-pull-requests-limit: 10
     schedule:
       interval: "daily"

--- a/requirements/requirements.crypto.txt
+++ b/requirements/requirements.crypto.txt
@@ -2,4 +2,4 @@ pycparser>=2.22,<4.0.0
 argon2-cffi-bindings>=21.2.0,<30.0.0
 argon2-cffi>=25.1.0,<26.0.0
 cryptography>=44.0.3,<47.0.0
-PyJWT[crypto]>=2.10.1,<3.0.0
+PyJWT[crypto]>=2.12.1,<3.0.0

--- a/requirements/requirements.crypto.txt
+++ b/requirements/requirements.crypto.txt
@@ -1,5 +1,5 @@
 pycparser>=2.22,<4.0.0
-argon2-cffi-bindings>=21.2.0,<30.0.0
+argon2-cffi-bindings>=25.1.0,<30.0.0
 argon2-cffi>=25.1.0,<26.0.0
 cryptography>=44.0.3,<47.0.0
 PyJWT[crypto]>=2.10.1,<3.0.0

--- a/requirements/requirements.test.txt
+++ b/requirements/requirements.test.txt
@@ -1,4 +1,4 @@
 pytest>=8.0.2,<10.0.0
 pytest-cov>=5.0.0,<8.0.0
 pytest-xdist>=3.6.1,<4.0.0
-pytest-benchmark>=5.0.1,<6.0.0
+pytest-benchmark>=5.2.3,<6.0.0

--- a/src/potato_util/crypto/symmetric/aes_gcm.py
+++ b/src/potato_util/crypto/symmetric/aes_gcm.py
@@ -152,7 +152,6 @@ def decrypt(
     if base64_decode:
         nonce = base64.b64decode(nonce)
         ciphertext = base64.b64decode(ciphertext)
-        aad = base64.b64decode(aad) if aad else None
 
     _message = "Decrypting ciphertext using AES-GCM key and nonce..."
     if warn_mode == WarnEnum.ALWAYS:


### PR DESCRIPTION
This pull request updates several dependencies and makes a minor configuration change to Dependabot. It also includes a small code cleanup in the `decrypt` function. These changes help keep the project up-to-date and improve maintainability.

**Dependency updates:**

* Bumped `argon2-cffi-bindings` to `>=25.1.0,<30.0.0` and `PyJWT[crypto]` to `>=2.12.1,<3.0.0` in `requirements/requirements.crypto.txt` to address security and compatibility.
* Updated `pytest-benchmark` to `>=5.2.3,<6.0.0` in `requirements/requirements.test.txt` for improved testing and benchmarking.

**Configuration changes:**

* Added `versioning-strategy: "widen"` to the Dependabot configuration in `.github/dependabot.yml` to allow a broader range of dependency updates.

**Code cleanup:**

* Removed unnecessary base64 decoding of `aad` in the `decrypt` function in `src/potato_util/crypto/symmetric/aes_gcm.py`.