### PR TITLE
Fixing import error

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ import potato_util.sanitizer as sanitizer_utils
 import potato_util.validator as validator_utils
 import potato_util.http as http_utils
 import potato_util.crypto.jwt as jwt_utils
+import potato_util.io as io_utils
 
 logger = logging.getLogger(__name__)
 
@@ -327,6 +328,14 @@ def main() -> None:
         logger.error("JWT token is expired!")
     except jwt.InvalidTokenError:
         logger.error("JWT token is invalid!")
+
+    logger.info("-" * 80)
+
+    # IO utils:
+    logger.info("[IO UTILITIES]")
+    io_utils.create_dir("test_dir", warn_mode="ALWAYS")
+    io_utils.remove_dir("test_dir", warn_mode="ALWAYS")
+    logger.info("-" * 80)
 
     return
 

--- a/examples/simple/main.py
+++ b/examples/simple/main.py
@@ -18,6 +18,7 @@ import potato_util.sanitizer as sanitizer_utils
 import potato_util.validator as validator_utils
 import potato_util.http as http_utils
 import potato_util.crypto.jwt as jwt_utils
+import potato_util.io as io_utils
 
 logger = logging.getLogger(__name__)
 
@@ -187,6 +188,14 @@ def main() -> None:
         logger.error("JWT token is expired!")
     except jwt.InvalidTokenError:
         logger.error("JWT token is invalid!")
+
+    logger.info("-" * 80)
+
+    # IO utils:
+    logger.info("[IO UTILITIES]")
+    io_utils.create_dir("test_dir", warn_mode="ALWAYS")
+    io_utils.remove_dir("test_dir", warn_mode="ALWAYS")
+    logger.info("-" * 80)
 
     return
 

--- a/src/potato_util/io/__init__.py
+++ b/src/potato_util/io/__init__.py
@@ -4,8 +4,7 @@ import importlib.util
 
 from ._sync import *
 
-_async_package_name = "aiofiles"
-_async_spec = importlib.util.find_spec(_async_package_name)
-
-if _async_spec is not None:
+if (importlib.util.find_spec("aiofiles") is not None) and (
+    importlib.util.find_spec("aioshutil") is not None
+):
     from ._async import *


### PR DESCRIPTION
This pull request introduces IO utility support to the project, allowing for directory creation and removal using the new `potato_util.io` module. The changes update both the codebase and example usage to demonstrate and utilize these new IO utilities, and enhance the dynamic import logic for asynchronous IO support.

**IO Utilities Integration:**

* Added import of `potato_util.io` as `io_utils` in both `README.md` and `examples/simple/main.py` to enable access to IO utility functions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R161) [[2]](diffhunk://#diff-f86920b486ef2a3f0e3d86f3222c57a889e559c826bbd5e1bdacc0aa00eaca23R21)
* Updated the `main()` function in both `README.md` and `examples/simple/main.py` to demonstrate usage of `io_utils.create_dir` and `io_utils.remove_dir`, including logging for IO operations. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R332-R339) [[2]](diffhunk://#diff-f86920b486ef2a3f0e3d86f3222c57a889e559c826bbd5e1bdacc0aa00eaca23R192-R199)

**Async IO Import Logic:**

* Improved the conditional import in `src/potato_util/io/__init__.py` to require both `aiofiles` and `aioshutil` to be available before importing asynchronous IO utilities, ensuring more robust async support.